### PR TITLE
Require lwt 2.5.0 or higher

### DIFF
--- a/opam
+++ b/opam
@@ -16,6 +16,6 @@ depends: [
   "ounit" {test}
   "ppx_deriving"
   "stringext"
-  "lwt"
+  "lwt" {>= "2.5.0"}
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
This is required because of the use of `Lwt.return_some` (see
http://ocsigen.org/lwt/changelog).
