### PR TITLE
Improve `parse` API

### DIFF
--- a/lib/multipart.ml
+++ b/lib/multipart.ml
@@ -371,7 +371,21 @@ let read_string_part reader boundary =
   iter_part reader boundary append_to_value >>
   Lwt.return @@ strip_crlf (Buffer.contents value)
 
-let read_part reader boundary callback fields =
+type callbacks =
+  { default : name:string -> filename:string -> string -> unit Lwt.t
+  ; named : (string * (string option ref * (string -> unit Lwt.t))) list
+  }
+
+let get_callback name filename callbacks =
+  match List.assoc name callbacks.named with
+  | (filename_ref, named_callback) ->
+    begin
+      filename_ref := Some filename;
+      named_callback
+    end
+  | exception Not_found -> callbacks.default ~name ~filename
+
+let read_part reader boundary callbacks fields =
   let%lwt headers = read_headers reader in
   let content_disposition = List.assoc "Content-Disposition" headers in
   let name =
@@ -380,13 +394,14 @@ let read_part reader boundary callback fields =
     | None -> invalid_arg "handle_multipart"
   in
   match parse_filename content_disposition with
-  | Some filename -> read_file_part reader boundary (callback ~name ~filename)
+  | Some filename ->
+      read_file_part reader boundary @@ get_callback name filename callbacks
   | None ->
     let%lwt value = read_string_part reader boundary in
     fields := (name, value)::!fields;
     Lwt.return_unit
 
-let handle_multipart reader boundary callback =
+let handle_multipart reader boundary callbacks =
   let fields = (ref [] : (string * string) list ref) in
   let%lwt () =
     let%lwt dummyline = Reader.read_line reader in
@@ -395,16 +410,24 @@ let handle_multipart reader boundary callback =
       if%lwt Reader.empty reader then
         Lwt.return (fin := true)
       else
-        read_part reader boundary callback fields
+        read_part reader boundary callbacks fields
     done
   in
   Lwt.return (!fields)
 
-let parse ~stream ~content_type ~callback =
+let ignore_callback ~name ~filename chunk =
+  Lwt.return_unit
+
+let parse ~content_type ?(default_callback=ignore_callback) ?(callbacks=[]) stream =
   let reader = Reader.make stream in
   let boundary =
     match extract_boundary content_type with
     | Some s -> "--" ^ s
     | None -> invalid_arg "iter_multipart"
   in
-  handle_multipart reader boundary callback
+  let callbacks =
+    { default = default_callback
+    ; named = callbacks
+    }
+  in
+  handle_multipart reader boundary callbacks

--- a/lib/multipart.mli
+++ b/lib/multipart.mli
@@ -23,8 +23,22 @@ module StringMap : Map.S with type key = string
 
 val get_parts : stream_part Lwt_stream.t -> [`String of string | `File of file] StringMap.t Lwt.t
 
+(** Low level interface.
+
+    To parse only string parts, just call [parse ~content_type body]: it will
+    return an association list.
+
+    To parse a file pass a callback in [callbacks] using the part name, a
+    reference and a function. The reference will be set to the file name, and
+    the function will be called on file chunks to save the file. String parts
+    are returned as an association list.
+
+    When a file part is encountered and no corresponding callback exists, the
+    [default_callback] function is called on every chunk.
+*)
 val parse :
-        stream:string Lwt_stream.t
-     -> content_type:string
-     -> callback:(name:string -> filename:string -> string -> unit Lwt.t)
+     content_type:string
+     -> ?default_callback:(name:string -> filename:string -> string -> unit Lwt.t)
+     -> ?callbacks:((string * (string option ref * (string -> unit Lwt.t))) list)
+     -> string Lwt_stream.t
      -> (string * string) list Lwt.t

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -54,23 +54,21 @@ let test_parse () =
   in
   Lwt_main.run thread
 
-let tc content_type chunks expected_parts expected_calls =
+let tc content_type chunks expected_parts expected_calls expected_filename =
   let stream = Lwt_stream.of_list chunks in
   let calls = ref [] in
-  let callback ~name ~filename line =
-    calls := !calls @ [(name, filename, line)];
+  let bar_callback line =
+    calls := !calls @ [line];
     Lwt.return_unit
   in
-  let%lwt parts = Multipart.parse ~stream ~content_type ~callback in
-  let string2_list = Alcotest.(list (pair string string)) in
-  let string3_list =
-    let pp fmt x =
-      Format.pp_print_string fmt ([%show: (string * string * string) list] x)
-    in
-    Alcotest.testable pp [%eq: (string * string * string) list]
+  let bar_filename = ref None in
+  let%lwt parts =
+    Multipart.parse ~content_type ~callbacks:[("bar", (bar_filename, bar_callback))] stream
   in
+  let string2_list = Alcotest.(list (pair string string)) in
   Alcotest.check string2_list "parts" expected_parts parts;
-  Alcotest.check string3_list "calls" expected_calls !calls;
+  Alcotest.check Alcotest.(list string) "calls" expected_calls !calls;
+  Alcotest.check Alcotest.(option string) "filename" expected_filename (!bar_filename);
   Lwt.return_unit
 
 let test_parse_request () =
@@ -104,10 +102,11 @@ let test_parse_request () =
           ]
       )
       [ ("foo", "toto") ]
-      [ ("bar", "filename.data", "line1\nline2\n")
-      ; ("bar", "filename.data", "line3\nline4\n")
-      ; ("bar", "filename.data", "line5\nline6\n")
+      [ "line1\nline2\n"
+      ; "line3\nline4\n"
+      ; "line5\nline6\n"
       ]
+      (Some "filename.data")
       >>
     tc
       "multipart/form-data; boundary=9219489391874b51bb29b52a10e8baac"
@@ -122,6 +121,7 @@ let test_parse_request () =
       )
       [ ("foo", "toto") ]
       []
+      None
   in
   Lwt_main.run thread
 


### PR DESCRIPTION
Previously it would call a single function for all parts. This does not
really represent the common use cases, where the caller knows what part
names to expect.

Using the `callbacks` argument, one can pass an association list mapping
expected part names to:

- a reference that will hold the filename
- a callback invoked on every chunk of the file

An extra `default_callback` argument is provided for parts whose name is
not known in advance, which is not usual but keeps the generality of the
former API.