### PR TITLE
Implement section 4.3 of RFC7578 - multipart form data

### DIFF
--- a/lib/multipart_form_data.ml
+++ b/lib/multipart_form_data.ml
@@ -1,107 +1,80 @@
-module StringMap = Map.Make(String)
+module StringMap = Map.Make (String)
 
 let string_eq ~a ~a_start ~b ~len =
   let r = ref true in
   for i = 0 to len - 1 do
     let a_i = a_start + i in
     let b_i = i in
-    if a.[a_i] <> b.[b_i] then
-      r := false
+    if a.[a_i] <> b.[b_i] then r := false
   done;
   !r
 
 let ends_with ~suffix ~suffix_length s =
   let s_length = String.length s in
-  (s_length >= suffix_length) &&
-  (string_eq ~a:s ~a_start:(s_length - suffix_length) ~b:suffix ~len:suffix_length)
+  s_length >= suffix_length
+  && string_eq ~a:s ~a_start:(s_length - suffix_length) ~b:suffix
+       ~len:suffix_length
 
 let rec first_matching p = function
   | [] -> None
-  | x::xs ->
-    begin
-      match p x with
-      | Some y -> Some y
-      | None -> first_matching p xs
-    end
+  | x :: xs -> (
+      match p x with Some y -> Some y | None -> first_matching p xs )
 
-let option_map f = function
-  | None -> None
-  | Some x -> Some (f x)
+let option_map f = function None -> None | Some x -> Some (f x)
 
 let find_common_idx a b =
   let rec go i =
-    if i <= 0 then
-      None
-    else
-      begin
-        if ends_with ~suffix:b ~suffix_length:i a then
-          Some (String.length a - i)
-        else
-          go (i - 1)
-      end
+    if i <= 0 then None
+    else if ends_with ~suffix:b ~suffix_length:i a then
+      Some (String.length a - i)
+    else go (i - 1)
   in
   go (String.length b)
 
-let word = function
-  | "" -> []
-  | w -> [Some w]
+let word = function "" -> [] | w -> [ Some w ]
 
 let split_on_string ~pattern s =
   let pattern_length = String.length pattern in
   let rec go start acc =
     match Stringext.find_from ~start s ~pattern with
     | Some match_start ->
-      let before = String.sub s start (match_start - start) in
-      let new_acc = None::(word before)@acc in
-      let new_start = match_start + pattern_length in
-      go new_start new_acc
-    | None ->
-      (word (Stringext.string_after s start))@acc
+        let before = String.sub s start (match_start - start) in
+        let new_acc = (None :: word before) @ acc in
+        let new_start = match_start + pattern_length in
+        go new_start new_acc
+    | None -> word (Stringext.string_after s start) @ acc
   in
   List.rev (go 0 [])
 
 let split_and_process_string ~boundary s =
-  let f = function
-    | None -> `Delim
-    | Some w -> `Word w
-  in
+  let f = function None -> `Delim | Some w -> `Word w in
   List.map f @@ split_on_string ~pattern:boundary s
 
 let split s boundary =
   let r = ref None in
-  let push v =
-    match !r with
-    | None -> r := Some v
-    | Some _ -> assert false
-  in
+  let push v = match !r with None -> r := Some v | Some _ -> assert false in
   let pop () =
     let res = !r in
     r := None;
     res
   in
   let go c0 =
-    let c =
-      match pop () with
-      | Some x -> x ^ c0
-      | None -> c0
-    in
-    let string_to_process = match find_common_idx c boundary with
-    | None -> c
-    | Some idx ->
-      begin
-        let prefix = String.sub c 0 idx in
-        let suffix = String.sub c idx (String.length c - idx) in
-        push suffix;
-        prefix
-      end
+    let c = match pop () with Some x -> x ^ c0 | None -> c0 in
+    let string_to_process =
+      match find_common_idx c boundary with
+      | None -> c
+      | Some idx ->
+          let prefix = String.sub c 0 idx in
+          let suffix = String.sub c idx (String.length c - idx) in
+          push suffix;
+          prefix
     in
     Lwt.return @@ split_and_process_string ~boundary string_to_process
   in
   let initial = Lwt_stream.map_list_s go s in
   let final =
-    Lwt_stream.flatten @@
-    Lwt_stream.from_direct @@ fun () ->
-    option_map (split_and_process_string ~boundary) @@ pop ()
+    Lwt_stream.flatten @@ Lwt_stream.from_direct
+    @@ fun () -> option_map (split_and_process_string ~boundary) @@ pop ()
   in
   Lwt_stream.append initial final
 
@@ -109,26 +82,24 @@ let until_next_delim s =
   Lwt_stream.from @@ fun () ->
   let%lwt res = Lwt_stream.get s in
   match res with
-  | None
-  | Some `Delim -> Lwt.return_none
+  | None | Some `Delim -> Lwt.return_none
   | Some (`Word w) -> Lwt.return_some w
 
 let join s =
-  Lwt_stream.filter_map (function
+  Lwt_stream.filter_map
+    (function
       | `Delim -> Some (until_next_delim @@ Lwt_stream.clone s)
-      | `Word _ -> None
-    ) s
+      | `Word _ -> None)
+    s
 
-let align stream boundary =
-  join @@ split stream boundary
+let align stream boundary = join @@ split stream boundary
 
 type header = string * string
 
 let extract_boundary content_type =
   Stringext.chop_prefix ~prefix:"multipart/form-data; boundary=" content_type
 
-let unquote s =
-  Scanf.sscanf s "%S" @@ (fun x -> x);;
+let unquote s = Scanf.sscanf s "%S" @@ fun x -> x
 
 let parse_name s =
   option_map unquote @@ Stringext.chop_prefix ~prefix:"form-data; name=" s
@@ -142,42 +113,38 @@ let non_empty st =
   let%lwt r = Lwt_stream.to_list @@ Lwt_stream.clone st in
   Lwt.return (String.concat "" r <> "")
 
-let get_headers : string Lwt_stream.t Lwt_stream.t -> header list Lwt.t
-  = fun lines ->
+let get_headers : string Lwt_stream.t Lwt_stream.t -> header list Lwt.t =
+ fun lines ->
   let%lwt header_lines = Lwt_stream.get_while_s non_empty lines in
-  Lwt_list.map_s (fun header_line_stream ->
+  Lwt_list.map_s
+    (fun header_line_stream ->
       let%lwt parts = Lwt_stream.to_list header_line_stream in
-      Lwt.return @@ parse_header @@ String.concat "" parts
-    ) header_lines
+      Lwt.return @@ parse_header @@ String.concat "" parts)
+    header_lines
 
-type stream_part =
-  { headers : header list
-  ; body : string Lwt_stream.t
-  }
+type stream_part = { headers : header list; body : string Lwt_stream.t }
 
 let parse_part chunk_stream =
   let lines = align chunk_stream "\r\n" in
   match%lwt get_headers lines with
   | [] -> Lwt.return_none
   | headers ->
-    let body = Lwt_stream.concat @@ Lwt_stream.clone lines in
-    Lwt.return_some { headers ; body }
+      let body = Lwt_stream.concat @@ Lwt_stream.clone lines in
+      Lwt.return_some { headers; body }
 
 let parse_stream ~stream ~content_type =
   match extract_boundary content_type with
   | None -> Lwt.fail_with "Cannot parse content-type"
   | Some boundary ->
-    begin
-      let actual_boundary = ("--" ^ boundary) in
-      Lwt.return @@ Lwt_stream.filter_map_s parse_part @@ align stream actual_boundary
-    end
+      let actual_boundary = "--" ^ boundary in
+      Lwt.return
+      @@ Lwt_stream.filter_map_s parse_part
+      @@ align stream actual_boundary
 
-let s_part_body {body; _} = body
+let s_part_body { body; _ } = body
 
-let s_part_name {headers; _} =
-  match
-    parse_name @@ List.assoc "Content-Disposition" headers
-  with
+let s_part_name { headers; _ } =
+  match parse_name @@ List.assoc "Content-Disposition" headers with
   | Some x -> x
   | None -> invalid_arg "s_part_name"
 
@@ -185,68 +152,70 @@ let parse_filename s =
   let parts = split_on_string s ~pattern:"; " in
   let f = function
     | None -> None
-    | Some part ->
-      begin
+    | Some part -> (
         match Stringext.cut part ~on:"=" with
         | Some ("filename", quoted_string) -> Some (unquote quoted_string)
-        | _ -> None
-      end
+        | _ -> None )
   in
   first_matching f parts
 
-let s_part_filename {headers; _} =
+let s_part_filename { headers; _ } =
   parse_filename @@ List.assoc "Content-Disposition" headers
 
 type file = stream_part
 
 let file_stream = s_part_body
+
 let file_name = s_part_name
 
-let file_content_type {headers; _} =
-  List.assoc "Content-Type" headers
+let file_content_type { headers; _ } = List.assoc "Content-Type" headers
 
 let as_part part =
   match s_part_filename part with
-  | Some _filename ->
-      Lwt.return (`File part)
+  | Some _filename -> Lwt.return (`File [ part ])
   | None ->
-    let%lwt chunks = Lwt_stream.to_list part.body in
-    let body = String.concat "" chunks in
-    Lwt.return (`String body)
+      let%lwt chunks = Lwt_stream.to_list part.body in
+      let body = String.concat "" chunks in
+      Lwt.return (`String [ body ])
+
+exception Invalid_part of string
+
+let get_file_part = function
+  | `File l -> l
+  | `String _ ->
+      raise @@ Invalid_part "expected `File part but got `String part"
+
+let get_string_part = function
+  | `File _ -> raise @@ Invalid_part "expected `String part but got `File part"
+  | `String l -> l
 
 let get_parts s =
   let go part m =
     let name = s_part_name part in
     let%lwt parsed_part = as_part part in
-    Lwt.return @@ StringMap.add name parsed_part m
+    Lwt.return
+    @@ StringMap.update name
+         (function
+           | None -> Some parsed_part
+           | Some (`File l) ->
+               `File (l @ get_file_part parsed_part) |> Option.some
+           | Some (`String l) ->
+               `String (l @ get_string_part parsed_part) |> Option.some)
+         m
   in
   Lwt_stream.fold_s go s StringMap.empty
 
-let concat a b =
-  match (a, b) with
-  | (_, "") -> a
-  | ("", _) -> b
-  | _ -> a ^ b
+let concat a b = match (a, b) with _, "" -> a | "", _ -> b | _ -> a ^ b
 
 module Reader = struct
-  type t =
-    { mutable buffer : string
-    ; source : string Lwt_stream.t
-    }
+  type t = { mutable buffer : string; source : string Lwt_stream.t }
 
-  let make stream =
-    { buffer = ""
-    ; source = stream
-    }
+  let make stream = { buffer = ""; source = stream }
 
-  let unread r s =
-    r.buffer <- concat s r.buffer
+  let unread r s = r.buffer <- concat s r.buffer
 
   let empty r =
-    if r.buffer = "" then
-      Lwt_stream.is_empty r.source
-    else
-      Lwt.return false
+    if r.buffer = "" then Lwt_stream.is_empty r.source else Lwt.return false
 
   let read_next r =
     let%lwt next_chunk = Lwt_stream.next r.source in
@@ -255,31 +224,20 @@ module Reader = struct
 
   let read_chunk r =
     try%lwt
-      let%lwt () =
-        if r.buffer = "" then
-          read_next r
-        else
-          Lwt.return_unit
-      in
+      let%lwt () = if r.buffer = "" then read_next r else Lwt.return_unit in
       let res = r.buffer in
       r.buffer <- "";
       Lwt.return (Some res)
-    with Lwt_stream.Empty ->
-      Lwt.return None
+    with Lwt_stream.Empty -> Lwt.return None
 
   let buffer_contains r s =
-    match Stringext.cut r.buffer ~on:s with
-    | Some _ -> true
-    | None -> false
+    match Stringext.cut r.buffer ~on:s with Some _ -> true | None -> false
 
   let rec read_until r cond =
-    if cond () then
-      Lwt.return_unit
+    if cond () then Lwt.return_unit
     else
-      begin
-        let%lwt () = read_next r in
-        read_until r cond
-      end
+      let%lwt () = read_next r in
+      read_until r cond
 
   let read_line r =
     let delim = "\r\n" in
@@ -287,51 +245,42 @@ module Reader = struct
     match Stringext.cut r.buffer ~on:delim with
     | None -> assert false
     | Some (line, next) ->
-      begin
         r.buffer <- next;
         Lwt.return (line ^ delim)
-      end
 end
 
 let read_headers reader =
   let rec go headers =
     let%lwt line = Reader.read_line reader in
-    if line = "\r\n" then
-      Lwt.return headers
+    if line = "\r\n" then Lwt.return headers
     else
       let header = parse_header line in
-      go (header::headers)
+      go (header :: headers)
   in
   go []
 
 let rec compute_case reader boundary =
   match%lwt Reader.read_chunk reader with
   | None -> Lwt.return `Empty
-  | Some line ->
-    begin
+  | Some line -> (
       match Stringext.cut line ~on:(boundary ^ "\r\n") with
       | Some (pre, post) -> Lwt.return @@ `Boundary (pre, post)
-      | None ->
-        begin
+      | None -> (
           match Stringext.cut line ~on:(boundary ^ "--\r\n") with
           | Some (pre, post) -> Lwt.return @@ `Boundary (pre, post)
-          | None ->
-            begin
+          | None -> (
               match find_common_idx line boundary with
               | Some 0 ->
-                begin
-                Reader.unread reader line;
-                let%lwt () = Reader.read_next reader in
-                compute_case reader boundary
-                end
+                  Reader.unread reader line;
+                  let%lwt () = Reader.read_next reader in
+                  compute_case reader boundary
               | Some amb_idx ->
-                let unambiguous = String.sub line 0 amb_idx in
-                let ambiguous = String.sub line amb_idx (String.length line - amb_idx) in
-                Lwt.return @@ `May_end_with_boundary (unambiguous, ambiguous)
-              | None -> Lwt.return @@ `App_data line
-            end
-        end
-    end
+                  let unambiguous = String.sub line 0 amb_idx in
+                  let ambiguous =
+                    String.sub line amb_idx (String.length line - amb_idx)
+                  in
+                  Lwt.return @@ `May_end_with_boundary (unambiguous, ambiguous)
+              | None -> Lwt.return @@ `App_data line ) ) )
 
 let iter_part reader boundary callback =
   let fin = ref false in
@@ -342,28 +291,24 @@ let iter_part reader boundary callback =
   let handle ~send ~unread ~finish =
     let%lwt () = callback send in
     Reader.unread reader unread;
-    if finish then
-      last ()
-    else
-      Lwt.return_unit
+    if finish then last () else Lwt.return_unit
   in
   while%lwt not !fin do
     let%lwt res = compute_case reader boundary in
     match res with
     | `Empty -> last ()
     | `Boundary (pre, post) -> handle ~send:pre ~unread:post ~finish:true
-    | `May_end_with_boundary (unambiguous, ambiguous) -> handle ~send:unambiguous ~unread:ambiguous ~finish:false
+    | `May_end_with_boundary (unambiguous, ambiguous) ->
+        handle ~send:unambiguous ~unread:ambiguous ~finish:false
     | `App_data line -> callback line
   done
 
-let read_file_part reader boundary callback =
-  iter_part reader boundary callback
+let read_file_part reader boundary callback = iter_part reader boundary callback
 
 let strip_crlf s =
   if ends_with ~suffix:"\r\n" ~suffix_length:2 s then
     String.sub s 0 (String.length s - 2)
-  else
-    s
+  else s
 
 let read_string_part reader boundary =
   let value = Buffer.create 0 in
@@ -382,9 +327,9 @@ let read_part reader boundary callback fields =
   match parse_filename content_disposition with
   | Some filename -> read_file_part reader boundary (callback ~name ~filename)
   | None ->
-    let%lwt value = read_string_part reader boundary in
-    fields := (name, value)::!fields;
-    Lwt.return_unit
+      let%lwt value = read_string_part reader boundary in
+      fields := (name, value) :: !fields;
+      Lwt.return_unit
 
 let handle_multipart reader boundary callback =
   let fields = (ref [] : (string * string) list ref) in
@@ -392,13 +337,11 @@ let handle_multipart reader boundary callback =
     let%lwt _dummyline = Reader.read_line reader in
     let fin = ref false in
     while%lwt not !fin do
-      if%lwt Reader.empty reader then
-        Lwt.return (fin := true)
-      else
-        read_part reader boundary callback fields
+      if%lwt Reader.empty reader then Lwt.return (fin := true)
+      else read_part reader boundary callback fields
     done
   in
-  Lwt.return (!fields)
+  Lwt.return !fields
 
 let parse ~stream ~content_type ~callback =
   let reader = Reader.make stream in

--- a/lib/multipart_form_data.mli
+++ b/lib/multipart_form_data.mli
@@ -1,7 +1,7 @@
+val align : string Lwt_stream.t -> string -> string Lwt_stream.t Lwt_stream.t
 (**
    Align a stream on a particular sequence and remove these boundaries.
  *)
-val align : string Lwt_stream.t -> string -> string Lwt_stream.t Lwt_stream.t
 
 type stream_part
 
@@ -11,20 +11,31 @@ val s_part_body : stream_part -> string Lwt_stream.t
 
 val s_part_filename : stream_part -> string option
 
-val parse_stream : stream:string Lwt_stream.t -> content_type:string -> stream_part Lwt_stream.t Lwt.t
+val parse_stream :
+  stream:string Lwt_stream.t ->
+  content_type:string ->
+  stream_part Lwt_stream.t Lwt.t
 
 type file
 
 val file_name : file -> string
+
 val file_content_type : file -> string
+
 val file_stream : file -> string Lwt_stream.t
 
 module StringMap : Map.S with type key = string
 
-val get_parts : stream_part Lwt_stream.t -> [`String of string | `File of file] StringMap.t Lwt.t
+exception Invalid_part of string
+
+val get_parts :
+  stream_part Lwt_stream.t ->
+  [ `String of string list | `File of file list ] StringMap.t Lwt.t
+(** [get_parts s] returns multipart form data as [`String l] or [`File l].
+     raises [Invalid_part] if there is a part mismatch. *)
 
 val parse :
-        stream:string Lwt_stream.t
-     -> content_type:string
-     -> callback:(name:string -> filename:string -> string -> unit Lwt.t)
-     -> (string * string) list Lwt.t
+  stream:string Lwt_stream.t ->
+  content_type:string ->
+  callback:(name:string -> filename:string -> string -> unit Lwt.t) ->
+  (string * string) list Lwt.t

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -4,85 +4,131 @@ let get_file name parts =
   | `String _ -> failwith "expected a file"
 
 module String_or_file = struct
-  type t = [`String of string | `File of Multipart_form_data.file]
+  type t = [ `String of string list | `File of Multipart_form_data.file list ]
 
-  let equal = (=)
+  let equal = ( = )
 
   let pp fmt (part : t) =
-    let s = match part with
-    | `File _ -> "File _"
-    | `String s -> s
-    in
-    Format.pp_print_string fmt s
+    let l = match part with `File _ -> [ "File _" ] | `String l -> l in
+    Format.pp_print_list
+      ~pp_sep:(fun fmt () -> Format.fprintf fmt ",")
+      Format.pp_print_string fmt l
 end
 
-let string_or_file = (module String_or_file : Alcotest.TESTABLE with type t = String_or_file.t)
+let string_or_file =
+  (module String_or_file : Alcotest.TESTABLE with type t = String_or_file.t)
 
 let test_parse () =
   let body =
     String.concat "\r\n"
-      [ {|--------------------------1605451f456c9a1a|}
-      ; {|Content-Disposition: form-data; name="a"|}
-      ; {||}
-      ; {|b|}
-      ; {|--------------------------1605451f456c9a1a|}
-      ; {|Content-Disposition: form-data; name="c"|}
-      ; {||}
-      ; {|d|}
-      ; {|--------------------------1605451f456c9a1a|}
-      ; {|Content-Disposition: form-data; name="upload"; filename="testfile"|}
-      ; {|Content-Type: application/octet-stream|}
-      ; {||}
-      ; {|testfilecontent|}
-      ; {||}
-      ; {|--------------------------1605451f456c9a1a|}
-      ; {|Content-Disposition: form-data; name="upload2"; filename="binary"|}
-      ; {|Content-Type: application/octet-stream|}
-      ; {||}
-      ; {|aωb|}
-      ; {||}
-      ; {|--------------------------1605451f456c9a1a|}
-      ; {|Content-Disposition: form-data; name="upload3"; filename="a.html"|}
-      ; {|Content-Type: text/html|}
-      ; {||}
-      ; {|<!DOCTYPE html><title>Content of a.html.</title>|}
-      ; {||}
-      ; {|--------------------------1605451f456c9a1a|}
-      ; {|Content-Disposition: form-data; name="upload4"; filename="a.txt"|}
-      ; {|Content-Type: text/plain|}
-      ; {||}
-      ; {|Content of a.txt.|}
-      ; {||}
-      ; {|--------------------------1605451f456c9a1a--|}
+      [
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="a"|};
+        {||};
+        {|b|};
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="a"|};
+        {||};
+        {|b2|};
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="c"|};
+        {||};
+        {|d|};
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="upload"; filename="testfile1"|};
+        {|Content-Type: application/octet-stream|};
+        {||};
+        {|testfilecontent1|};
+        {||};
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="upload"; filename="testfile2"|};
+        {|Content-Type: application/octet-stream|};
+        {||};
+        {|testfilecontent2|};
+        {||};
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="upload2"; filename="binary"|};
+        {|Content-Type: application/octet-stream|};
+        {||};
+        {|aωb|};
+        {||};
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="upload3"; filename="a.html"|};
+        {|Content-Type: text/html|};
+        {||};
+        {|<!DOCTYPE html><title>Content of a.html.</title>|};
+        {||};
+        {|--------------------------1605451f456c9a1a|};
+        {|Content-Disposition: form-data; name="upload4"; filename="a.txt"|};
+        {|Content-Type: text/plain|};
+        {||};
+        {|Content of a.txt.|};
+        {||};
+        {|--------------------------1605451f456c9a1a--|};
       ]
   in
-  let content_type = "multipart/form-data; boundary=------------------------1605451f456c9a1a" in
-  let stream = Lwt_stream.of_list [body] in
+  let content_type =
+    "multipart/form-data; boundary=------------------------1605451f456c9a1a"
+  in
+  let stream = Lwt_stream.of_list [ body ] in
   let thread =
-    let%lwt parts_stream = Multipart_form_data.parse_stream ~stream ~content_type in
+    let%lwt parts_stream =
+      Multipart_form_data.parse_stream ~stream ~content_type
+    in
     let%lwt parts = Multipart_form_data.get_parts parts_stream in
-    Alcotest.check string_or_file "'a' value" (`String "b") (Multipart_form_data.StringMap.find "a" parts);
-    Alcotest.check string_or_file "'c' value" (`String "d") (Multipart_form_data.StringMap.find "c" parts);
-    let file = get_file "upload" parts in
-    Alcotest.check Alcotest.string "filename" "upload" (Multipart_form_data.file_name file);
-    Alcotest.check Alcotest.string "content_type" "application/octet-stream" (Multipart_form_data.file_content_type file);
-    let%lwt file_chunks = Lwt_stream.to_list (Multipart_form_data.file_stream file) in
-    Alcotest.check Alcotest.string "contents" "testfilecontent" (String.concat "" file_chunks);
-    let file = get_file "upload2" parts in
-    Alcotest.check Alcotest.string "filename" "upload2" (Multipart_form_data.file_name file);
-    Alcotest.check Alcotest.string "content_type" "application/octet-stream" (Multipart_form_data.file_content_type file);
-    let%lwt file_chunks = Lwt_stream.to_list (Multipart_form_data.file_stream file) in
-    Alcotest.check Alcotest.string "contents" "aωb" (String.concat "" file_chunks);
-    let file = get_file "upload3" parts in
-    Alcotest.check Alcotest.string "filename" "upload3" (Multipart_form_data.file_name file);
-    Alcotest.check Alcotest.string "content_type" "text/html" (Multipart_form_data.file_content_type file);
-    let%lwt file_chunks = Lwt_stream.to_list (Multipart_form_data.file_stream file) in
-    Alcotest.check Alcotest.string "contents" "<!DOCTYPE html><title>Content of a.html.</title>" (String.concat "" file_chunks);
-    let file = get_file "upload4" parts in
-    Alcotest.check Alcotest.string "filename" "upload4" (Multipart_form_data.file_name file);
-    Alcotest.check Alcotest.string "content_type" "text/plain" (Multipart_form_data.file_content_type file);
-    let%lwt file_chunks = Lwt_stream.to_list (Multipart_form_data.file_stream file) in
-    Alcotest.check Alcotest.string "contents" "Content of a.txt." (String.concat "" file_chunks);
+    Alcotest.check string_or_file "'a' value"
+      (`String [ "b"; "b2" ])
+      (Multipart_form_data.StringMap.find "a" parts);
+    Alcotest.check string_or_file "'c' value"
+      (`String [ "d" ])
+      (Multipart_form_data.StringMap.find "c" parts);
+    let files = get_file "upload" parts in
+    Alcotest.check Alcotest.string "filename" "upload"
+      (Multipart_form_data.file_name (List.hd files));
+    Alcotest.check Alcotest.string "content_type" "application/octet-stream"
+      (Multipart_form_data.file_content_type (List.hd files));
+    let%lwt file_chunks =
+      Lwt_stream.to_list (Multipart_form_data.file_stream (List.hd files))
+    in
+    Alcotest.check Alcotest.string "contents" "testfilecontent1"
+      (String.concat "" file_chunks);
+    let%lwt file_chunks =
+      Lwt_stream.to_list (Multipart_form_data.file_stream (List.nth files 1))
+    in
+    Alcotest.check Alcotest.string "contents" "testfilecontent2"
+      (String.concat "" file_chunks);
+
+    let files = get_file "upload2" parts in
+    Alcotest.check Alcotest.string "filename" "upload2"
+      (Multipart_form_data.file_name (List.hd files));
+    Alcotest.check Alcotest.string "content_type" "application/octet-stream"
+      (Multipart_form_data.file_content_type (List.hd files));
+    let%lwt file_chunks =
+      Lwt_stream.to_list (Multipart_form_data.file_stream (List.hd files))
+    in
+    Alcotest.check Alcotest.string "contents" "aωb"
+      (String.concat "" file_chunks);
+    let files = get_file "upload3" parts in
+    Alcotest.check Alcotest.string "filename" "upload3"
+      (Multipart_form_data.file_name (List.hd files));
+    Alcotest.check Alcotest.string "content_type" "text/html"
+      (Multipart_form_data.file_content_type (List.hd files));
+    let%lwt file_chunks =
+      Lwt_stream.to_list (Multipart_form_data.file_stream (List.hd files))
+    in
+    Alcotest.check Alcotest.string "contents"
+      "<!DOCTYPE html><title>Content of a.html.</title>"
+      (String.concat "" file_chunks);
+    let files = get_file "upload4" parts in
+    Alcotest.check Alcotest.string "filename" "upload4"
+      (Multipart_form_data.file_name (List.hd files));
+    Alcotest.check Alcotest.string "content_type" "text/plain"
+      (Multipart_form_data.file_content_type (List.hd files));
+    let%lwt file_chunks =
+      Lwt_stream.to_list (Multipart_form_data.file_stream (List.hd files))
+    in
+    Alcotest.check Alcotest.string "contents" "Content of a.txt."
+      (String.concat "" file_chunks);
 
     Lwt.return_unit
   in
@@ -92,7 +138,7 @@ let tc content_type chunks expected_parts expected_calls =
   let stream = Lwt_stream.of_list chunks in
   let calls = ref [] in
   let callback ~name ~filename line =
-    calls := !calls @ [((name, filename), line)];
+    calls := !calls @ [ ((name, filename), line) ];
     Lwt.return_unit
   in
   let%lwt parts = Multipart_form_data.parse ~stream ~content_type ~callback in
@@ -111,88 +157,93 @@ let test_parse_request () =
   let thread =
     let%lwt () =
       tc "multipart/form-data; boundary=9219489391874b51bb29b52a10e8baac"
-        ( List.map (String.concat "\n") @@
-          [ [ {|--9219489391874b51bb29b52a10e8baac|} ^ cr
-            ; {|Content-Disposition: form-data; name="foo"|} ^ cr
-            ; {||} ^ cr
-            ; {|toto|} ^ cr
-            ; {|--9219489391874b51bb29b52a10e8baac|} ^ cr
-            ; {|Content-Disposition: form-data; name="foo"|} ^ cr
-            ; {||} ^ cr
-            ; {|toto2|} ^ cr
-            ; {|--9219489391874b51bb29b52a10e8baac|} ^ cr
-            ; {|Content-Disposition: form-data; name="bar"; filename="filename.data"|} ^ cr
-            ; {|Content-Type: application/octet-stream|} ^ cr
-            ; {||} ^ cr
-            ; {|line1|}
-            ; {|line2|}
-            ; {||}
-            ]
-          ; [ {|line3|}
-            ; {|line4|}
-            ; {||}
-            ]
-          ; [ {|line5|}
-            ; {|line6|}
-            ; {|--9219489391874b51bb29b52a10e8baac--|} ^ cr
-            ; {||}
-            ]
-          ]
-        )
-        [ ("foo", "toto2"); ("foo", "toto")]
-        [ ("bar", "filename.data", "line1\nline2\n")
-        ; ("bar", "filename.data", "line3\nline4\n")
-        ; ("bar", "filename.data", "line5\nline6\n")
+        ( List.map (String.concat "\n")
+        @@ [
+             [
+               {|--9219489391874b51bb29b52a10e8baac|} ^ cr;
+               {|Content-Disposition: form-data; name="foo"|} ^ cr;
+               {||} ^ cr;
+               {|toto|} ^ cr;
+               {|--9219489391874b51bb29b52a10e8baac|} ^ cr;
+               {|Content-Disposition: form-data; name="foo"|} ^ cr;
+               {||} ^ cr;
+               {|toto2|} ^ cr;
+               {|--9219489391874b51bb29b52a10e8baac|} ^ cr;
+               {|Content-Disposition: form-data; name="bar"; filename="filename.data"|}
+               ^ cr;
+               {|Content-Type: application/octet-stream|} ^ cr;
+               {||} ^ cr;
+               {|line1|};
+               {|line2|};
+               {|--9219489391874b51bb29b52a10e8baac|} ^ cr;
+               {|Content-Disposition: form-data; name="bar"; filename="filename2.data"|}
+               ^ cr;
+               {|Content-Type: application/octet-stream|} ^ cr;
+               {||} ^ cr;
+               {|line1|};
+               {|line2|};
+               {||};
+             ];
+             [ {|line3|}; {|line4|}; {||} ];
+             [
+               {|line5|};
+               {|line6|};
+               {|--9219489391874b51bb29b52a10e8baac--|} ^ cr;
+               {||};
+             ];
+           ] )
+        [ ("foo", "toto2"); ("foo", "toto") ]
+        [
+          ("bar", "filename.data", "line1\nline2\n");
+          ("bar", "filename2.data", "line1\nline2\n");
+          ("bar", "filename2.data", "line3\nline4\n");
+          ("bar", "filename2.data", "line5\nline6\n");
         ]
     in
-    tc
-      "multipart/form-data; boundary=9219489391874b51bb29b52a10e8baac"
-      (
-        [ {|--9219489391874b51bb29b52a10e8baac|} ^ crlf
-        ; {|Content-Disposition: form-data; name="foo"|} ^ crlf
-        ; crlf
-        ; {|toto|} ^ crlf
-        ; {|--9219489391874b|}
-        ; {|51bb29b52a10e8baac--|} ^ crlf
-        ]
-      )
-      [ ("foo", "toto") ]
-      []
+    tc "multipart/form-data; boundary=9219489391874b51bb29b52a10e8baac"
+      [
+        {|--9219489391874b51bb29b52a10e8baac|} ^ crlf;
+        {|Content-Disposition: form-data; name="foo"|} ^ crlf;
+        crlf;
+        {|toto|} ^ crlf;
+        {|--9219489391874b|};
+        {|51bb29b52a10e8baac--|} ^ crlf;
+      ]
+      [ ("foo", "toto") ] []
   in
   Lwt_main.run thread
 
 let test_split () =
   let in_stream =
     Lwt_stream.of_list
-      [ "ABCD"
-      ; "EFap"
-      ; "ple"
-      ; "ABCDEFor"
-      ; "angeABC"
-      ; "HHpl"
-      ; "umABCDEFkiwi"
-      ; "ABCDEF"
+      [
+        "ABCD";
+        "EFap";
+        "ple";
+        "ABCDEFor";
+        "angeABC";
+        "HHpl";
+        "umABCDEFkiwi";
+        "ABCDEF";
       ]
   in
   let expected =
-    [ ["ap" ; "ple"]
-    ; ["or"; "ange"; "ABCHHpl"; "um"]
-    ; ["kiwi"]
-    ; []
-    ]
+    [ [ "ap"; "ple" ]; [ "or"; "ange"; "ABCHHpl"; "um" ]; [ "kiwi" ]; [] ]
   in
   let stream = Multipart_form_data.align in_stream "ABCDEF" in
-  Lwt_main.run (
-    let%lwt streams = Lwt_stream.to_list stream in
-    let%lwt result = Lwt_list.map_s Lwt_stream.to_list streams in
-    Alcotest.check Alcotest.(list (list string)) "contents" expected result;
-    Lwt.return_unit
-  )
+  Lwt_main.run
+    (let%lwt streams = Lwt_stream.to_list stream in
+     let%lwt result = Lwt_list.map_s Lwt_stream.to_list streams in
+     Alcotest.check Alcotest.(list (list string)) "contents" expected result;
+     Lwt.return_unit)
 
 let () =
-  Alcotest.run "multipart-form-data" [ ("Multipart_form_data",
-    [ "parse", `Quick, test_parse
-    ; "parse_request", `Quick, test_parse_request
-    ; "split", `Quick, test_split
+  Alcotest.run "multipart-form-data"
+    [
+      ( "Multipart_form_data",
+        [
+          ("parse", `Quick, test_parse);
+          ("parse_request", `Quick, test_parse_request);
+          ("split", `Quick, test_split);
+        ] );
     ]
-  )]


### PR DESCRIPTION
This PR implements section 4.3 of RFC7578, i.e. multiple files in one Form field [1] . 
I have also updated the tests to exercise this new functionality. 

It seems the higher level apis ```parse_stream, get_parts``` work quite well now. The README on this repo suggests not so. Should README be changed to remove that it doesn't work well?

I have also added ```.ocamlformat```. Not sure if this is welcome. Please let me know it this isn't desired. I will revert to non formatted version if required. 

Note: This is a breaking change from previous version.

[1] https://tools.ietf.org/html/rfc7578#section-4.3